### PR TITLE
Use new official CircleCI Docker orb, upgrade to 0.5.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  orb-tools: circleci/orb-tools@8.4.0
+  orb-tools: circleci/orb-tools@8.27.4
   docker-publish: upenn-libraries/docker-publish@dev:alpha
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Docker Publish Orb for CircleCI
 
-A [CircleCI Orb](https://circleci.com/docs/2.0/orb-intro/) used to build and publish Docker images. Based on the official [Docker Publish Orb](https://circleci.com/orbs/registry/orb/circleci/docker-publish); images are also labeled with build metadata and tagged with Git commit hashes.
+A [CircleCI Orb](https://circleci.com/docs/2.0/orb-intro/) used to build and publish Docker images. Based on the official [Docker Orb](https://circleci.com/orbs/registry/orb/circleci/docker); images are also labeled with build metadata and tagged with Git commit hashes.

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,4 +7,4 @@ description: |
   https://github.com/upenn-libraries/circleci_orb_docker_publish
 
 orbs:
-  docker-publish: circleci/docker@0.5.13
+  docker: circleci/docker@0.5.13

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -2,9 +2,9 @@ version: 2.1
 
 description: |
   Build and publish Docker images labeled with build metadata and tagged with
-  Git commit hashes. Based on the official circleci/docker-publish Orb
-  (https://circleci.com/orbs/registry/orb/circleci/docker-publish). Source:
+  Git commit hashes. Based on the official circleci/docker Orb
+  (https://circleci.com/orbs/registry/orb/circleci/docker). Source:
   https://github.com/upenn-libraries/circleci_orb_docker_publish
 
 orbs:
-  docker-publish: circleci/docker-publish@0.1.6
+  docker-publish: circleci/docker@0.5.13

--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -4,9 +4,9 @@ executor: << parameters.executor >>
 
 parameters:
   executor:
-    description: Image to use for running the Docker build. Defaults to docker-publish/docker.
+    description: Image to use for running the Docker build. Defaults to docker/docker.
     type: executor
-    default: docker-publish/docker
+    default: docker/docker
   dockerfile:
     description: Name of dockerfile to use. Defaults to Dockerfile.
     type: string
@@ -64,7 +64,7 @@ steps:
   - when:
       condition: <<parameters.deploy>>
       steps:
-        - docker-publish/check:
+        - docker/check:
             registry: << parameters.registry >>
   - when:
       name: Run before_build lifecycle hook steps.
@@ -85,6 +85,6 @@ steps:
   - when:
       condition: <<parameters.deploy>>
       steps:
-        - docker-publish/deploy:
+        - docker/push:
             registry: << parameters.registry >>
             image: << parameters.image >>


### PR DESCRIPTION
CircleCI has deprecated the [circleci/docker-publish](https://circleci.com/orbs/registry/orb/circleci/docker-publish) orb to merge it with the [circleci/docker](https://circleci.com/orbs/registry/orb/circleci/docker) orb. We'll use that one moving forward. 🐳🌐 